### PR TITLE
Fix unmentioned dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PREFIX ?= /usr/local
 src = ipc.c util.c clipboard.c history.c content.c send_signal.c main.c
 headers = clipsim.h
 
-ldlibs = $(LDLIBS) -lX11 -lXfixes -lmagic
+ldlibs = $(LDLIBS) -lX11 -lXfixes -lmagic -lpthread
 
 all: release
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ $ yay -S clipsim
 ```
 
 ### Manual
-Make sure you have [libxfixes](https://gitlab.freedesktop.org/xorg/lib/libxfixes)
-and [xclip](https://github.com/astrand/xclip) installed.
+Make sure you have [libxfixes](https://gitlab.freedesktop.org/xorg/lib/libxfixes), [xclip](https://github.com/astrand/xclip) and libmagic installed.
 ```
 $ git clone https://codeberg.org/lucas.mior/clipsim.git clipsim
 $ cd clipsim


### PR DESCRIPTION
I found some issues during installation from sources:
1) You forgot to note in readme file, that this project depends on libmagic (linked in makefile).
2) My build failed with linking issue. It was connected with threads.h header, included in clipsim.h file. But it was not linked in makefile. So, I added -lpthread in makefile and it builded successfully.

I am not quite sure about last one, because I cannot imagine, how do you compile it without linking pthreads?