### PR TITLE
Explicitly ignore error value of write in error

### DIFF
--- a/util.c
+++ b/util.c
@@ -992,9 +992,13 @@ error(char *format, ...) {
 
     buffer[n] = '\0';
 #if OS_WINDOWS
-    write(STDERR_FILENO, buffer, (uint)n);
+    if (write(STDERR_FILENO, buffer, (uint)n) < 0) {
+        // Do nothing on error
+    }
 #else
-    write(STDERR_FILENO, buffer, (size_t)n);
+    if (write(STDERR_FILENO, buffer, (size_t)n) < 0) {
+        // Do nothing on error
+    }
     fsync(STDERR_FILENO);
     fsync(STDOUT_FILENO);
 #endif


### PR DESCRIPTION
When compiling it shoots out a warning of the write return value not being checked, in this case if it fails theres not much left to do, so just willingly ignore it and silence this warning only in this place